### PR TITLE
feat: font-lock for `record_field`

### DIFF
--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -296,9 +296,9 @@ PARENT is always optional_formal_parameters."
    :language 'dart
    :feature 'property
    `((unconditional_assignable_selector
-      (identifier) @font-lock-property-face)
+      (identifier) @font-lock-property-name-face)
      (conditional_assignable_selector
-      (identifier) @font-lock-property-face))
+      (identifier) @font-lock-property-name-face))
 
    :language 'dart
    :feature 'function

--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -253,6 +253,8 @@ PARENT is always optional_formal_parameters."
      (type_alias
       (type_identifier) @font-lock-type-face)
      (void_type) @font-lock-type-face
+     (record_field
+      (label (identifier) @font-lock-type-face))
      ((scoped_identifier
        scope: (identifier) @font-lock-type-face
        name: (identifier) @font-lock-type-face)


### PR DESCRIPTION
Only for src like this:

```dart
var record = ('first', a: 2, b: true, 'last');
```

After this patch, `a` and `b` will be highlighted as `type`.

---

Code like this will not be highlighted:

```dart
var (i as int, s as String) = record;
```

tree-sitter-dart has error when parsing `i` and `s` for now, need to wait for upstream updates