### PR TITLE
More reasonable treesit-font-lock-feature-list

### DIFF
--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -148,17 +148,17 @@ PARENT is always optional_formal_parameters."
     "await" "get" "interface" "show"
     "hide" "on" "class" "enum" "extends"
     "in" "is" "new" "return"
-    "super" "with" "if" "else"
+    "super" "with" "if" "else" "when"
     "try" "catch" "default" "switch")
   "Dart keywords for tree-sitter font-locking.")
 
 (defvar dart-ts-mode--builtins
-  '("abstract" "as" "covariant" "deferred"
+  '("abstract" "as" "base" "covariant" "deferred"
     "dynamic" "export" "extension" "external"
     "factory" "Function" "get" "implements"
     "import" "interface" "late" "library"
     "mixin" "operator" "part" "required"
-    "set" "static" "typedef")
+    "sealed" "set" "static" "typedef")
   "Dart builtins for tree-sitter font locking.")
 
 (defvar dart-ts-mode--operators
@@ -170,10 +170,38 @@ PARENT is always optional_formal_parameters."
 (defvar dart-ts-mode--font-lock-settings
   (treesit-font-lock-rules
    :language 'dart
-   :override t
    :feature 'comment
    `((comment) @font-lock-comment-face
      (documentation_comment) @font-lock-comment-face)
+
+   :language 'dart
+   :feature 'definition
+   `((class_definition
+      name: (identifier) @font-lock-type-face)
+     (constant_pattern
+      (identifier) @font-lock-variable-name-face)
+     (object_pattern
+      ((identifier) @font-lock-variable-name-face))
+     (named_argument
+      (label (identifier) @font-lock-variable-name-face))
+     (record_field
+      (label (identifier) @font-lock-variable-name-face))
+     (initialized_identifier
+      (identifier) @font-lock-variable-name-face)
+     (initialized_variable_definition
+      name: (identifier) @font-lock-variable-name-face)
+     (static_final_declaration
+      (identifier) @font-lock-variable-name-face)
+     (constant_constructor_signature
+      (identifier) @font-lock-function-name-face)
+     (constructor_signature
+      name: (identifier) @font-lock-function-name-face)
+     (function_signature
+      name: (identifier) @font-lock-function-name-face)
+     (getter_signature
+      name: (identifier) @font-lock-function-name-face)
+     (setter_signature
+      name: (identifier) @font-lock-function-name-face))
 
    :language 'dart
    :feature 'constant
@@ -186,7 +214,6 @@ PARENT is always optional_formal_parameters."
    `([,@dart-ts-mode--keywords] @font-lock-keyword-face
      [,@dart-ts-mode--builtins] @font-lock-builtin-face
      [(break_statement) (continue_statement)] @font-lock-keyword-face
-     [(this) (super) (inferred_type)] @font-lock-keyword-face
      (case_builtin) @font-lock-keyword-face
      ((identifier) @font-lock-type-face
       (:match "^_?[A-Z].*[a-z]" @font-lock-type-face))
@@ -198,7 +225,6 @@ PARENT is always optional_formal_parameters."
      (for_statement "for" @font-lock-keyword-face))
 
    :language 'dart
-   :override t
    :feature 'operator
    `([,@dart-ts-mode--operators
       (multiplicative_operator)
@@ -215,7 +241,6 @@ PARENT is always optional_formal_parameters."
    '((["(" ")" "[" "]" "{" "}"]) @font-lock-bracket-face)
 
    :language 'dart
-   :override t
    :feature 'string
    `((string_literal) @font-lock-string-face
      ((template_substitution
@@ -228,70 +253,40 @@ PARENT is always optional_formal_parameters."
      (dotted_identifier_list) @font-lock-string-face)
 
    :language 'dart
-   :override t
    :feature 'literal
    `([(hex_integer_literal) (decimal_integer_literal) (decimal_floating_point_literal)] @font-lock-number-face
      (symbol_literal) @font-lock-constant-face
      [(true) (false) (null_literal)] @font-lock-constant-face)
 
    :language 'dart
-   :override t
    :feature 'type
-   `((constructor_signature
+   `((type_identifier) @font-lock-type-face
+     (inferred_type) @font-lock-type-face
+     (enum_declaration
       name: (identifier) @font-lock-type-face)
      (scoped_identifier
       scope: (identifier) @font-lock-type-face)
-     (function_signature
-      name: (identifier) @font-lock-function-name-face)
-     (getter_signature
-      (identifier) @font-lock-function-name-face)
-     (setter_signature
-      name: (identifier) @font-lock-function-name-face)
-     (enum_declaration
-      name: (identifier) @font-lock-type-face)
-     (type_identifier) @font-lock-type-face
      (type_alias
       (type_identifier) @font-lock-type-face)
      (void_type) @font-lock-type-face
-     (record_field
-      (label (identifier) @font-lock-type-face))
      ((scoped_identifier
        scope: (identifier) @font-lock-type-face
        name: (identifier) @font-lock-type-face)
       (:match "^[a-zA-Z]" @font-lock-type-face)))
 
    :language 'dart
-   :override t
-   :feature 'annotation
-   `((annotation
-      name: (identifier) @font-lock-constant-face)
-     ["@"] @font-lock-constant-face
-     (marker_annotation
-      name: (identifier) @font-lock-constant-face))
-
-   :language 'dart
-   :feature 'method
-   `((function_signature
-      name: (identifier) @font-lock-function-name-face)
-     (setter_signature
-      name: (identifier) @font-lock-function-name-face))
-
-   :language 'dart
-   :override t
-   :feature 'definition
-   `((class_definition
-      name: (identifier) @font-lock-type-face)
-     (initialized_identifier
-      (identifier) @font-lock-variable-name-face)
-     (initialized_variable_definition
-      name: (identifier) @font-lock-variable-name-face)
-     (static_final_declaration
-      (identifier) @font-lock-variable-name-face))
-
-   :language 'dart
    :feature 'assignment
    `((assignment_expression
-      left: (assignable_expression (identifier) @font-lock-variable-name-face)))
+      left: (assignable_expression (identifier) @font-lock-variable-use-face)))
+
+   :language 'dart
+   :feature 'annotation
+   `((annotation
+      "@" @font-lock-constant-face
+      name: (identifier) @font-lock-constant-face)
+     (marker_annotation
+      "@" @font-lock-constant-face
+      name: (identifier) @font-lock-constant-face))
 
    :language 'dart
    :feature 'property
@@ -302,7 +297,8 @@ PARENT is always optional_formal_parameters."
 
    :language 'dart
    :feature 'function
-   `((super) @font-lock-function-call-face)
+   :override t
+   `([(super) (this)] @font-lock-function-call-face)
 
    :language 'dart
    :feature 'number
@@ -322,14 +318,15 @@ PARENT is always optional_formal_parameters."
 
 (defvar dart-ts-mode--sentence-nodes
   '(
-    "import_statement"
+    "assert_statement"
     "debugger_statement"
     "expression_statement"
+    "formal_parameter"
     "if_statement"
+    "import_statement"
+    "optional_formal_parameters"
     "switch_statement"
     "variable_declaration"
-    "formal_parameter"
-    "optional_formal_parameters"
     )
   "Nodes that designate sentences in Dart.
 See `treesit-sentence-type-regexp' for more information.")
@@ -423,13 +420,12 @@ Return nil if there is no name or if NODE is not a defun node."
 
     ;; Font-lock.
     (setq-local treesit-font-lock-settings dart-ts-mode--font-lock-settings)
-
-    ;; FIXME More reasonable feature list.
     (setq-local treesit-font-lock-feature-list
-                '((comment escape-sequence)
-                  (constant keyword string type assignment definition)
-                  (annotation expression literal property)
-                  (bracket delimiter operator number)))
+                '(( comment definition)
+                  ( keyword string type)
+                  ( assignment constant annotation number literal
+                    escape-sequence expression property)
+                  ( delimiter operator bracket)))
 
     (treesit-major-mode-setup))
   )


### PR DESCRIPTION
* Follow the convention of `treesit-font-lock-level`

Level 1 usually contains only comments and definitions.

Level 2 usually adds keywords, strings, data types, etc.

Level 3 usually represents full-blown fontifications, including assignments, constants, numbers and literals, etc.

Level 4 adds everything else that can be fontified: delimiters, operators, brackets, punctuation, all functions, properties, variables, etc.

* Change font-lock to corresponding face

There is still a lot of work to be done, for now I just made modifications that I met.

* Add keywords `when`, `base` and `sealed`

https://dart.dev/language/keywords