### PR TITLE
Fix: match the upstream modification

### DIFF
--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -287,8 +287,7 @@ PARENT is always optional_formal_parameters."
    :override t
    '((annotation
       "@" @font-lock-constant-face
-      name: (identifier) @font-lock-constant-face)
-     (marker_annotation) @font-lock-constant-face)
+      name: (identifier) @font-lock-constant-face))
 
    :language 'dart
    :feature 'escape-sequence


### PR DESCRIPTION
After tree-sitter-dart's update:

https://github.com/UserNobody14/tree-sitter-dart/commit/b55b90fe7d504b324d0357d69dc7eed631a3996b

`marker_annotation` has been abandoned, since we had not released a stable version, I guess we needn't make it backward compatibility.

---

For ref: https://github.com/UserNobody14/tree-sitter-dart/issues/51#issuecomment-1690851892