### PR TITLE
Add indent for switch pattern case

### DIFF
--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -74,6 +74,7 @@
      ;; ((parent-is "formal_parameter") parent-bol dart-ts-mode-indent-offset)
      ((parent-is "function_expression_body") parent-bol dart-ts-mode-indent-offset)
      ((n-p-gp nil "switch_block" "switch_statement") dart-ts-mode--switch-case-indent-rule dart-ts-mode-indent-offset)
+     ((parent-is "switch_expression") parent-bol dart-ts-mode-indent-offset)
      ((parent-is "if_statement") parent-bol dart-ts-mode-indent-offset)
      ((parent-is "variable_declarator") parent-bol dart-ts-mode-indent-offset)
      ((parent-is "list_literal") parent-bol dart-ts-mode-indent-offset)


### PR DESCRIPTION
e.g.

```dart
class _DemoState extends ConsumerState<DemoPage> {
  @override
  Widget build(BuildContext context) {
    final data = ref.watch(demoProvider);

    return RefreshIndicator(
      onRefresh: () async {
        ref.invalidate(demoProvider);
      },
      child: switch (data) {
        AsyncData(:final value) => Text('123'),                   //
        AsyncError() => const Widget(),                           // Add indent here.
        _ => const Center(child: CircularProgressIndicator()),    //
      },
    );
  }
}

```