### PR TITLE
Add indent for anonymous function statement

### DIFF
--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -89,8 +89,8 @@
 
      (no-node parent-bol 0))))
 
-(defun dart-ts-mode--node-start (node)
-  "Return NODE's start position."
+(defun dart-ts-mode--node-bol (node)
+  "Return NODE's bol position."
   (save-excursion
     (goto-char (treesit-node-start node))
     (back-to-indentation)
@@ -98,7 +98,7 @@
 
 (defun dart-ts-mode--parent-start (node)
   "Return the position of the first character of NODE's parent."
-  (dart-ts-mode--node-start (treesit-node-parent node)))
+  (treesit-node-start (treesit-node-parent node)))
 
 (defun dart-ts-mode--if-statement-indent-rule (_ parent &rest __)
   "Indent rule for if_statement.
@@ -108,20 +108,19 @@ returns parent-bol of grandparent.Otherwise returns bol of grandparent."
     (if (and (treesit-node-p gp)
              (string= "if_statement" (treesit-node-string gp)))
         (dart-ts-mode--parent-start gp)
-      (dart-ts-mode--node-start gp))))
+      (dart-ts-mode--node-bol gp))))
 
 (defun dart-ts-mode--switch-case-indent-rule (node parent &rest __)
   "Indent rule for a NODE under switch_block.
-If NODE is switch's label, returns PARENT's start position.
-Otherwise returns PARENT's start position plus
-`dart-ts-mode-indent-offset'."
-  (let ((parent-start (dart-ts-mode--node-start parent))
+If NODE is switch's label, returns PARENT's bol.  Otherwise
+returns PARENT's bol plus `dart-ts-mode-indent-offset'."
+  (let ((parent-bol (dart-ts-mode--node-bol parent))
         (node-name (treesit-node-type node)))
     (if (or (string= "switch_label" node-name)
             (string= "switch_statement_case" node-name)
             (string= "switch_statement_default" node-name))
-        parent-start
-      (+ parent-start dart-ts-mode-indent-offset))))
+        parent-bol
+      (+ parent-bol dart-ts-mode-indent-offset))))
 
 (defun dart-ts-mode--arguments-indent-rule (node parent &rest _)
   "Return indentation of argument list.
@@ -130,7 +129,7 @@ starting point of first sibling."
   (let ((first-sibling (treesit-node-child parent 0 t)))
     (if (and first-sibling (not (treesit-node-eq first-sibling node)))
         (treesit-node-start first-sibling)
-      (+ (dart-ts-mode--node-start parent) dart-ts-mode-indent-offset))))
+      (+ (dart-ts-mode--node-bol parent) dart-ts-mode-indent-offset))))
 
 (defun dart-ts-mode--function-body-indent-rule (_node parent &rest _)
   "Indent rule for NODE inside function body.

--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -97,7 +97,7 @@
     (point)))
 
 (defun dart-ts-mode--parent-start (node)
-  "Return the position of the first character of NODE's parent."
+  "Return the position of NODE's parent."
   (treesit-node-start (treesit-node-parent node)))
 
 (defun dart-ts-mode--if-statement-indent-rule (_node parent &rest _)
@@ -156,14 +156,13 @@ node."
         (treesit-node-start ggp)))
      (t (dart-ts-mode--node-bol parent)))))
 
-(defun dart-ts-mode--optional-formal-parameters-indent-rule (_ parent &rest __)
+(defun dart-ts-mode--optional-formal-parameters-indent-rule (_node parent &rest _)
   "Return indentation of children of optional_formal_parameters.
 PARENT is always optional_formal_parameters."
-  (let ((parent-sibling (treesit-node-prev-sibling parent)))
-    (if (and (treesit-node-p parent-sibling)
-             (string= (treesit-node-string parent-sibling) "formal_parameter"))
-        (treesit-node-start parent-sibling)
-      (+ (dart-ts-mode--parent-start parent) dart-ts-mode-indent-offset))))
+  (let ((formal-sib (treesit-node-prev-sibling parent "formal_parameter")))
+    (if (treesit-node-p formal-sib)
+        (treesit-node-start formal-sib)
+      (+ (dart-ts-mode--node-bol parent) dart-ts-mode-indent-offset))))
 
 (defvar dart-ts-mode--keywords
   '("async" "async*" "await" "catch" "class"

--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -100,27 +100,26 @@
   "Return the position of the first character of NODE's parent."
   (treesit-node-start (treesit-node-parent node)))
 
-(defun dart-ts-mode--if-statement-indent-rule (_ parent &rest __)
+(defun dart-ts-mode--if-statement-indent-rule (_node parent &rest _)
   "Indent rule for if_statement.
-If parent of PARENT (a.k.a grandparent) is if_statement,
-returns parent-bol of grandparent.Otherwise returns bol of grandparent."
+If parent of PARENT (a.k.a grandparent) is if_statement, returns
+parent of grandparent.  Otherwise returns bol of grandparent."
   (let ((gp (treesit-node-parent parent)))
-    (if (and (treesit-node-p gp)
-             (string= "if_statement" (treesit-node-string gp)))
+    (if (string= "if_statement" (treesit-node-string gp))
         (dart-ts-mode--parent-start gp)
       (dart-ts-mode--node-bol gp))))
 
-(defun dart-ts-mode--switch-case-indent-rule (node parent &rest __)
+(defun dart-ts-mode--switch-case-indent-rule (node parent &rest _)
   "Indent rule for a NODE under switch_block.
-If NODE is switch's label, returns PARENT's bol.  Otherwise
-returns PARENT's bol plus `dart-ts-mode-indent-offset'."
-  (let ((parent-bol (dart-ts-mode--node-bol parent))
+If NODE is switch's label, returns PARENT's parent .  Otherwise
+returns grandparent's plus `dart-ts-mode-indent-offset'."
+  (let ((gp-start (treesit-node-start (treesit-node-parent parent)))
         (node-name (treesit-node-type node)))
     (if (or (string= "switch_label" node-name)
             (string= "switch_statement_case" node-name)
             (string= "switch_statement_default" node-name))
-        parent-bol
-      (+ parent-bol dart-ts-mode-indent-offset))))
+        gp-start
+      (+ gp-start dart-ts-mode-indent-offset))))
 
 (defun dart-ts-mode--arguments-indent-rule (node parent &rest _)
   "Return indentation of argument list.


### PR DESCRIPTION
e.g.

```dart
return OutlinedButton(
  onPressed: disable.value
      ? null
      : () {
          print('123123');        // Add indent here
        },
  child: Text(demo.value),
);
```

---

Besides, I didn't get it why we need a `dart-ts-mode--node-start` here, since we already have a bultin `treesit-node-start`.

https://github.com/50ways2sayhard/dart-ts-mode/blob/035484366fa9b306f52b0df5c08758969b5d50a0/dart-ts-mode.el#L91-L96

Using `back-to-indentation` may move the point to a wrong place, like the above example, when the node is `() { ...`. After using `back-to-indentation`, cursor will be move to `:`, which is not the parent of the NODE we're operating.