### PR TITLE
Highlight for as keyword in for collection elements

### DIFF
--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -272,6 +272,7 @@ definition names.")
      [(const_builtin) (final_builtin) (case_builtin)] @font-lock-keyword-face
      [(super) (this)] @font-lock-keyword-face
      (for_statement "for" @font-lock-keyword-face)
+     (for_element "for" @font-lock-keyword-face)
      (finally_clause "finally" @font-lock-keyword-face)
      (part_of_directive (part_of_builtin) @font-lock-builtin-face)
      (function_type "Function" @font-lock-keyword-face)


### PR DESCRIPTION
This ensures the highlighting of `for` as a keyword in expressions like: `{for (final x in myList) x.id: x.value}`