### PR TITLE
Remove ` from Dart syntax table

### DIFF
--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -67,7 +67,6 @@
     (modify-syntax-entry ?\n "> b"  table)
     (modify-syntax-entry ?\^m "> b" table)
     (modify-syntax-entry ?$ "_" table)
-    (modify-syntax-entry ?` "\"" table)
     table)
   "Syntax table for `dart-ts-mode'.")
 


### PR DESCRIPTION
Dart does not use backticks, so they shouldn't demarcate strings in the syntax table.