### PR TITLE
Minor font-lock fixes

### DIFF
--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -287,8 +287,6 @@ definition names.")
       name: (identifier) @font-lock-type-face)
      (class_definition
       "final" @font-lock-keyword-face)
-     ((identifier) @font-lock-type-face
-      (:match "\\`_?[A-Z]" @font-lock-type-face))
      (object_pattern
       ((identifier) @font-lock-variable-name-face))
      (constant_pattern
@@ -326,8 +324,7 @@ definition names.")
    '((string_literal) @font-lock-string-face
      (template_substitution) @font-lock-variable-name-face
      (template_substitution
-      "$" @font-lock-function-call-face)
-     (dotted_identifier_list) @font-lock-string-face)
+      "$" @font-lock-escape-face))
 
    :language 'dart
    :feature 'type
@@ -383,7 +380,7 @@ definition names.")
    :feature 'number
    '([(hex_integer_literal)
       (decimal_integer_literal)
-      (decimal_floating_point_literal)] @font-lock-constant-face)
+      (decimal_floating_point_literal)] @font-lock-number-face)
 
    :language 'dart
    :feature 'literal


### PR DESCRIPTION
A few different fixes to font-lock rules:
1. Removed type face from the definition feature. It is redundant since it is also specified in the type feature, with override `t`.
2. Removed the dotted_identifier element from string_literals. It is redundant since it only re-applies the font-lock-string-face that is already set by string_literal
3. Emacs 29 introduced font-lock-number-face for numbers. By default it inherits font-lock-constant-face so this will not affect most people, but gives a little more freedom to customize their syntax highlighting.