### PR TITLE
Make tree-sitter sexp config more granular

### DIFF
--- a/dart-ts-mode.el
+++ b/dart-ts-mode.el
@@ -535,9 +535,18 @@ Return nil if there is no name or NODE."
         ;; Emacs 30+.
         (setq-local treesit-thing-settings
                     `((dart
-                       ;; It's more useful to include semicolons as sexp so
-                       ;; that users can move to the end of a statement.
-                       (sexp (not ,(rx (or "{" "}" "[" "]" "(" ")" ","))))
+                       ;; Only leaf-level and balanced-expression nodes are sexps
+                       (sexp ,(rx string-start
+                                  (or "identifier" "type_identifier"
+                                      "inferred_type" "void_type" "function_type"
+                                      "true" "false" "this" "super"
+                                      "annotation"
+                                      "comment" "documentation_comment"
+                                      "expression_statement"
+                                      "block" "arguments"
+                                      (seq (+ anything) "_literal")
+                                      (seq (+ anything) "_expression"))
+                                  string-end))
                        (sentence ,(regexp-opt dart-ts-mode--sentence-nodes))
                        (text ,(regexp-opt dart-ts-mode--text-nodes)))))
       ;; (setq-local treesit-sexp-type-regexp


### PR DESCRIPTION
This changes the treesit sexp setting to allowlist to make it more granular. With the previous denylist, container nodes (e.g. initialized_identifier_list) are considered sexps, making e.g. backward-sexp to move over entire declarations.

For example:
```
var hello = "hello";
```

```
final widget = Container()
  ..color = Colors.red
  ..padding = EdgeInsets.all(8)
  ..child = Text("hello");
```

In both cases, putting the cursor on the semicolon and calling backward-sexp moves all the way to the beginning of the line.